### PR TITLE
Wrote this using git web edit so it's untested. In 0.6 this will remove ...

### DIFF
--- a/feed.js
+++ b/feed.js
@@ -138,9 +138,7 @@ Feed.prototype.confirm = function confirm_feed() {
   })
   
   r.on('response', function () {
-    r.req.on('socket', function (s) {
-      s.emit('agentRemove')
-    })
+    r.req.socket.emit('agentRemove')
   })
 }
 


### PR DESCRIPTION
...the http request for follow from the Agent so that long running follow connection don't overload the socket pool in node.
