### PR TITLE
TypeError: Cannot read property 'body' of undefined

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -208,7 +208,7 @@ Feed.prototype.query = function query_feed() {
   function on_feed_response(er, resp, body) {
     clearTimeout(response_timer)
 
-    if(resp.body || body)
+    if((resp !== undefined && resp.body) || body)
       return self.die(new Error('Cannot handle a body in the feed response: ' + lib.JS(resp.body || body)))
 
     if(timed_out) {


### PR DESCRIPTION
When couchdb gets stopped, this exception gets raised, which prevents reconnection when couchdb is up again

TypeError: Cannot read property 'body' of undefined
    at Request.on_feed_response [as onResponse](/home/node/local/node-0.6.6/lib/node_modules/cradle/node_modules/follow/lib/feed.js:211:12)
    at Request.<anonymous> (/home/node/local/node-0.6.6/lib/node_modules/cradle/node_modules/follow/node_modules/request/main.js:186:60)
    at Request.emit (events.js:67:17)
    at ClientRequest.<anonymous> (/home/node/local/node-0.6.6/lib/node_modules/cradle/node_modules/follow/node_modules/request/main.js:184:10)
    at ClientRequest.emit (events.js:67:17)
    at Socket.<anonymous> (http.js:1114:11)
    at Socket.emit (events.js:67:17)
    at Array.0 (net.js:313:25)
    at EventEmitter._tickCallback (node.js:192:40)
