### PR TITLE
req.query undefined in inline filter function

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -530,7 +530,7 @@ Feed.prototype.on_change = function on_change(change) {
 
   // Don't let the filter mutate the real data.
   var doc = lib.JDUP(change.doc);
-  var req = lib.JDUP({'query': self.pending.request.changes_query});
+  var req = lib.JDUP({'query': self.pending.request.source.changes_query});
 
   var result = false;
   try {


### PR DESCRIPTION
I kept getting an undefined req.query when using inline filters. 

Changing self.pending.request.changes_query to self.pending.source.changes_query on line 534 of feed.js seems to fix the problem.

Thanks.
