### PR TITLE
add a grace period to response timeout

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -29,6 +29,7 @@ var DEFAULT_HEARTBEAT = 30000;
 var HEARTBEAT_TIMEOUT_COEFFICIENT = 1.25; // E.g. heartbeat 1000ms would trigger a timeout after 1250ms of no heartbeat.
 var DEFAULT_MAX_RETRY_SECONDS     = 60 * 60;
 var INITIAL_RETRY_DELAY           = 1000;
+var RESPONSE_GRACE_TIME           = 5000;
 
 var FEED_PARAMETERS   = ['since', 'limit', 'feed', 'heartbeat', 'filter', 'include_docs', 'view'];
 
@@ -200,7 +201,7 @@ Feed.prototype.query = function query_feed() {
   })
 
   // The response headers must arrive within one heartbeat.
-  var response_timer = setTimeout(response_timed_out, self.heartbeat)
+  var response_timer = setTimeout(response_timed_out, self.heartbeat + RESPONSE_GRACE_TIME)
     , timed_out = false
 
   return self.emit('query', feed_request)


### PR DESCRIPTION
This change is required to function correctly with the cloudant service which can wait with the initial "200 OK" response until the grace period has elapsed.

The 5 second grace period is kinda arbitrary. The important part is that it is longer than the server -> client latency.
