### PR TITLE
allow non-integer sequence id's

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -135,7 +135,13 @@ Feed.prototype.confirm = function confirm_feed() {
       self.since = -1
     }
 
-    if(self.since < 0) {
+    if(self.since == -1) {
+      self.log.debug('Query since '+self.since+' will start at ' + db.update_seq)
+      self.since = db.update_seq
+    } else if(self.since < 0) {
+      if(isNaN(db.update_seq))
+        return self.emit('error', new Error('DB requires specific id in "since"'));
+
       self.log.debug('Query since '+self.since+' will start at ' + (db.update_seq + self.since + 1))
       self.since = db.update_seq + self.since + 1
     }
@@ -512,12 +518,12 @@ Feed.prototype.on_change = function on_change(change) {
   if(!change.seq)
     return self.die(new Error('No seq value in change: ' + lib.JS(change)));
 
-  if(change.seq <= self.since) {
+  if(change.seq == self.since) {
     self.log.debug('Bad seq value ' + change.seq + ' since=' + self.since);
     return destroy_req(self.pending.request);
   }
 
-  if(!self.caught_up && change.seq >= self.original_db_seq) {
+  if(!self.caught_up && change.seq == self.original_db_seq) {
     self.caught_up = true
     self.emit('catchup', change.seq)
   }


### PR DESCRIPTION
The cloudant service uses non-integer sequence id's. This patch will enable follow to work on the service for strings as well.
