### PR TITLE
handle request errors

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -209,6 +209,8 @@ Feed.prototype.query = function query_feed() {
     on_feed_response(null, res, res.body)
   })
 
+  feed_request.on('error', on_feed_response)
+
   // The response headers must arrive within one heartbeat.
   var response_timer = setTimeout(response_timed_out, self.heartbeat + RESPONSE_GRACE_TIME)
     , timed_out = false


### PR DESCRIPTION
Eg. if the CouchDB server goes down, the request will get an error.
