### PR TITLE
(#29) - Check for dead on confirm_request response

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -124,7 +124,7 @@ Feed.prototype.confirm = function confirm_feed() {
       return self.emit('error', json_er)
     }
 
-    if(!db.db_name || !db.instance_start_time)
+    if(!self.dead && (!db.db_name || !db.instance_start_time))
       return self.emit('error', new Error('Bad DB response: ' + body));
 
     self.original_db_seq = db.update_seq


### PR DESCRIPTION
Fixes #29: In case the confirm_request response comes after the feed was
stopped and the database was deleted a Bad DB response will rise.
