### PR TITLE
Allow request options override in confirm_feed

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -108,7 +108,12 @@ Feed.prototype.confirm = function confirm_feed() {
   var headers = lib.JP(lib.JS(self.headers));
   headers.accept = 'application/json';
 
-  var req = request({'uri':self.db, 'headers':headers}, db_response)
+  var query = {'uri':self.db, 'headers':headers};
+  Object.keys(self.request).forEach(function(key) {
+    query[key] = self.request[key];
+  })
+
+  var req = request(query, db_response)
   self.emit('confirm_request', req)
 
   function db_response(er, resp, body) {
@@ -339,7 +344,7 @@ Feed.prototype.wait = function wait_for_event() {
 
 Feed.prototype.got_activity = function() {
   var self = this
-  
+
   if (self.dead)
     return
 


### PR DESCRIPTION
Hello,

I've noticed `request` options weren't used on this particular part of code, I don't know if it's intended but it's very much needed in my case. I was wondering if it wouldn't be better done by using `request.defaults` but that would require a bigger change and I'm not sure you're willing to take it.
