### PR TITLE
Add 'conflicts' to list of available feed parameters

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -31,7 +31,7 @@ var DEFAULT_MAX_RETRY_SECONDS     = 60 * 60;
 var INITIAL_RETRY_DELAY           = 1000;
 var RESPONSE_GRACE_TIME           = 5000;
 
-var FEED_PARAMETERS   = ['since', 'limit', 'feed', 'heartbeat', 'filter', 'include_docs', 'view', 'style'];
+var FEED_PARAMETERS   = ['since', 'limit', 'feed', 'heartbeat', 'filter', 'include_docs', 'view', 'style', 'conflicts'];
 
 var EventEmitter = events.EventEmitter2 || events.EventEmitter;
 


### PR DESCRIPTION
This, when used in combination with include_docs=true will add the _conflicts property to docs included in the _changes feed.
