### PR TITLE
Bump request to ^2.44.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 , "repository": { "type": "git"
                 , "url": "git://github.com/iriscouch/follow" }
 , "engines": { "node": "0.10.x || 0.8.x" }
-, "dependencies" : { "request" : "~2.34.0"
+, "dependencies" : { "request" : "^2.44.0"
                    , "browser-request" : "~0.3.0"
                    , "debug": "~0.7.2"
                    }


### PR DESCRIPTION
I tried running tests, but they were failing for me before and after this change ;)

More recent versions of request have some ideal features. In particular, I want `follow` to work behind a http proxy. `request` 2.38 onwards will respect `http_proxy` environment var.
