### PR TITLE
Don't crash on timeout if the feed was stopped

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -455,6 +455,9 @@ Feed.prototype.on_couch_data = function on_couch_data(change) {
 
 Feed.prototype.on_timeout = function on_timeout() {
   var self = this;
+  if (self.dead)
+    return self.log.debug('No timeout: change listener stopped this feed');
+  
   self.log.debug('Timeout')
 
   var now = new Date;


### PR DESCRIPTION
`on_timeout` keeps causing crashing node for me because it gets called even after you do a `feed.stop()`. This may not be the proper solution but it at least stops things from crashing [in my case].
