### PR TITLE
Prevent options from overriding instance methods

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -62,7 +62,8 @@ function Feed (opts) {
     opts = {'db': opts};
 
   Object.keys(opts).forEach(function(key) {
-    self[key] = opts[key];
+    if (typeof self[key] !== 'function')
+      self[key] = opts[key];
   })
 
   self.pending = { request     : null


### PR DESCRIPTION
If you have something like:

```javascript
new follow.Feed({follow: false})
```

as [cradle has](https://github.com/flatiron/cradle/blob/master/lib/cradle/database/changes.js#L54), then your `Feed` instance will be bonkers (`#follow` will be `false`).

This PR adds a simple check that makes sure that options can't override instance's functions. A better solution would be perhaps to have a white-list of options that `Feed` accepts or just keep options as-is in `#options` instead of augmenting the instance itself.