### PR TITLE
Fix filters for _db_updates feeds: pass doc, type, req to filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ If CouchDB permanently crashes, there is an option of failure modes:
 If the db url ends with `/_db_updates`, Follow will provide a
 [_db_updates](http://docs.couchdb.org/en/latest/api/server/common.html?highlight=db_updates#get--_db_updates) feed.
 
+For each change, Follow will emit a `change` event containing:
+
+* `type`: `created`, `updated` or `deleted`.
+* `db_name`: Name of the database where the change occoured.
+* `ok`: Event operation status (boolean).
+
 Note that this feature is available as of CouchDB 1.4.
 
 ### Simple API: follow(options, callback)

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -458,7 +458,7 @@ Feed.prototype.on_timeout = function on_timeout() {
   var self = this;
   if (self.dead)
     return self.log.debug('No timeout: change listener stopped this feed');
-  
+
   self.log.debug('Timeout')
 
   var now = new Date;
@@ -560,16 +560,24 @@ Feed.prototype.on_change = function on_change(change) {
   if(typeof self.filter !== 'function')
     return self.on_good_change(change);
 
-  if(!change.doc)
-    return self.die(new Error('Internal filter needs .doc in change ' + change.seq));
-
-  // Don't let the filter mutate the real data.
-  var doc = lib.JDUP(change.doc);
   var req = lib.JDUP({'query': self.pending.request.changes_query});
+  var filter_args;
 
+  if (self.is_db_updates) {
+    if(!change.db_name || !change.type)
+      return self.die(new Error('Internal _db_updates filter needs .db_name and .type in change ', change));
+    filter_args = [change.db_name, change.type, req];
+  } else {
+    if(!change.doc)
+      return self.die(new Error('Internal filter needs .doc in change ' + change.seq));
+
+    // Don't let the filter mutate the real data.
+    var doc = lib.JDUP(change.doc);
+    filter_args = [doc, req];
+  }
   var result = false;
   try {
-    result = self.filter.apply(null, [doc, req]);
+    result = self.filter.apply(null, filter_args);
   } catch (er) {
     self.log.debug('Filter error', er);
   }

--- a/test/couch.js
+++ b/test/couch.js
@@ -9,10 +9,12 @@ var tap = require('tap')
 
 var follow = require('../api')
   , DB = process.env.db || 'http://localhost:5984/follow_test'
+  , DB_UPDATES = process.env.db_updates || 'http://localhost:5984/_db_updates'
   , RTT = null
 
 
 module.exports = { 'DB': DB
+                 , 'DB_UPDATES': DB_UPDATES
                  , 'rtt' : get_rtt
                  , 'redo': redo_couch
                  , 'setup': setup_test

--- a/test/follow.js
+++ b/test/follow.js
@@ -245,3 +245,22 @@ test('Handle a deleted database', function(t) {
     }
   })
 })
+
+test('Follow _db_updates', function (t) {
+    var db_name = couch.DB.split('/').slice(-1)[0];
+    var feed = new follow.Feed({db: couch.DB_UPDATES});
+    feed.on('error', function (error) {
+        t.false(error, 'Error in feed ' + error);
+    });
+    feed.on('change', function (change) {
+      t.ok(change, 'Received a change ' + JSON.stringify(change));
+      t.equal(change.type, 'updated', 'Change should be of type "updated');
+      t.equal(change.db_name, db_name, 'Change should have db_name with the name of the db where the change occoured.');
+      feed.stop();
+      t.end();
+    });
+    feed.start();
+    couch.make_data(1, function (result) {
+        t.ok(result, 'Created test data');
+    });
+});


### PR DESCRIPTION
This fixes an issue where trying to use a filter function on a `_db_updates` feed fails with the error "Internal filter needs .doc".

The `_db_updates` feeds have `db_name` and `type` instead of `doc`, so I pass these to the filter function.