### PR TITLE
Added options for heartbeat, max_retry_seconds, initial_retry_delay, response_grace_time

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ Besides the CouchDB options, more are available:
 
 * `headers` | Object with HTTP headers to add to the request
 * `inactivity_ms` | Maximum time to wait between **changes**. Omitting this means no maximum.
+* `max_retry_seconds` | Maximum time to wait between retries (default: 360 seconds)
+* `initial_retry_delay` | Time to wait before the first retry, in milliseconds (default 1000 milliseconds)
+* `response_grace_time` | Extra time to wait before timing out, in milliseconds (default 5000 milliseconds)
 
 ## Object API
 

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -44,9 +44,11 @@ function Feed (opts) {
   opts = opts || {}
 
   self.feed = 'continuous';
-  self.heartbeat         = DEFAULT_HEARTBEAT;
-  self.max_retry_seconds = DEFAULT_MAX_RETRY_SECONDS;
+  self.heartbeat         = opts.heartbeat || DEFAULT_HEARTBEAT;
+  self.max_retry_seconds = opts.max_retry_seconds || DEFAULT_MAX_RETRY_SECONDS;
   self.inactivity_ms = null;
+  self.initial_retry_delay = opts.initial_retry_delay || INITIAL_RETRY_DELAY;
+  self.response_grace_time = opts.response_grace_time || RESPONSE_GRACE_TIME;
 
   self.headers = {};
   self.request = opts.request || {} // Extra options for potentially future versions of request. The caller can supply them.
@@ -54,7 +56,7 @@ function Feed (opts) {
   self.since = 0;
   self.is_paused = false
   self.caught_up = false
-  self.retry_delay = INITIAL_RETRY_DELAY; // ms
+  self.retry_delay = self.initial_retry_delay;
 
   self.query_params = {}; // Extra `req.query` values for filter functions
 
@@ -233,7 +235,7 @@ Feed.prototype.query = function query_feed() {
   feed_request.on('error', on_feed_response)
 
   // The response headers must arrive within one heartbeat.
-  var response_timer = setTimeout(response_timed_out, self.heartbeat + RESPONSE_GRACE_TIME)
+  var response_timer = setTimeout(response_timed_out, self.heartbeat + self.response_grace_time)
     , timed_out = false
 
   return self.emit('query', feed_request)
@@ -268,7 +270,7 @@ Feed.prototype.query = function query_feed() {
     }
 
     self.log.debug('Good response: ' + feed_id);
-    self.retry_delay = INITIAL_RETRY_DELAY;
+    self.retry_delay = self.initial_retry_delay;
 
     self.emit('response', resp);
 
@@ -458,7 +460,7 @@ Feed.prototype.on_timeout = function on_timeout() {
   var self = this;
   if (self.dead)
     return self.log.debug('No timeout: change listener stopped this feed');
-  
+
   self.log.debug('Timeout')
 
   var now = new Date;


### PR DESCRIPTION
I needed to configure the retry delay, which can't be done without changes as the `query` method overrides it, so I've added an option for it on the constructor. I've also made the other parameters configurable, in order to have consistency (before, some parameters were passed as options, others had to be modified when the feed instance was already created).

Some of these settings are in seconds and others are in milliseconds, which is messy and error-prone. I haven't changed that so as to keep the change small and backwards compatible.