### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
             , "email": "jhs@iriscouch.com" }
 , "contributors": [ "Jarrett Cruger <jcrugzz@gmail.com>" ]
 , "description": "Extremely robust, fault-tolerant CouchDB changes follower"
-, "license": "Apache 2.0"
+, "license": "Apache-2.0"
 , "keywords": ["couchdb", "changes", "sleep", "sleepy"]
 , "homepage": "http://github.com/iriscouch/follow"
 , "repository": { "type": "git"


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

Changed to "Apache-2.0" per SPDX licenses page: https://spdx.org/licenses/