### PR TITLE
Retry change request on last_seq

### DIFF
--- a/lib/feed.js
+++ b/lib/feed.js
@@ -263,6 +263,15 @@ Feed.prototype.query = function query_feed() {
       return self.retry();
     }
 
+    if (resp.statusCode === 404) {
+      destroy_response(resp);
+      self.log.warn('Database not found. Stopping changes feed.');
+      var del_er = new Error('Database not found.');
+      del_er.deleted = true;
+      del_er.last_seq = self.since;
+      return self.die(del_er);
+    }
+
     if(resp.statusCode !== 200) {
       self.log.debug('Bad changes response ' + feed_id + ': ' + resp.statusCode);
       destroy_response(resp);
@@ -435,12 +444,10 @@ Feed.prototype.on_couch_data = function on_couch_data(change) {
   change = JSON.parse(change)
 
   //self.log.debug('Object:\n' + util.inspect(change));
-  if(!self.is_db_updates && 'last_seq' in change) {
-    self.log.warn('Stopping upon receiving a final message: ' + JSON.stringify(change))
-    var del_er = new Error('Database deleted after change: ' + change.last_seq)
-    del_er.deleted = true
-    del_er.last_seq = change.last_seq
-    return self.die(del_er)
+  if ('last_seq' in change) {
+    self.log.debug('Found last_seq in change: retrying request');
+    self.since = change.last_seq;
+    return self.retry();
   }
 
   if(!self.is_db_updates && !change.seq)


### PR DESCRIPTION
CouchDB terminates the changes feed, sending a `last_seq`, if the node serving your request is placed in maintenance mode (see https://github.com/apache/couchdb-fabric/blob/master/src/fabric_view_changes.erl#L94). The expectation here is that the client will retry the request using the `last_seq` provided in the response.

Currently follow is just throwing an error here under the false assumption that the database has been deleted. This change always retries the changes request if it's terminated by the server. Only when the following retry attempt returns a 404 do we mark the database as deleted and stop the feed.